### PR TITLE
Spawn non-static futures?

### DIFF
--- a/examples/spawn_borrow.rs
+++ b/examples/spawn_borrow.rs
@@ -9,13 +9,13 @@ use futures::executor;
 use lazy_static::lazy_static;
 
 type Task = async_task::Task<()>;
-type JoinHandle<T> = async_task::JoinHandle<'static, T, ()>;
+type JoinHandle<'a, T> = async_task::JoinHandle<'a, T, ()>;
 
 /// Spawns a future on the executor.
-fn spawn<F, R>(future: F) -> JoinHandle<R>
+fn spawn<'a, F, R>(future: F) -> JoinHandle<'a, R>
 where
-    F: Future<Output = R> + Send + 'static,
-    R: Send + 'static,
+    F: Future<Output = R> + Send + 'a,
+    R: Send + 'a,
 {
     lazy_static! {
         // A channel that holds scheduled tasks.
@@ -45,9 +45,16 @@ where
 }
 
 fn main() {
+
+    let borrow_me = 5;
+
+    let task = async {
+        println!("Hello, world: {}!", borrow_me);
+    };
+
     // Spawn a future and await its result.
-    let handle = spawn(async {
-        println!("Hello, world!");
-    });
+    // executor::block_on(task);
+
+    let handle = spawn( task );
     executor::block_on(handle);
 }

--- a/src/join_handle.rs
+++ b/src/join_handle.rs
@@ -15,20 +15,21 @@ use crate::state::*;
 ///
 /// * `None` indicates the task has panicked or was canceled.
 /// * `Some(result)` indicates the task has completed with `result` of type `R`.
-pub struct JoinHandle<R, T> {
+pub struct JoinHandle<'a, R, T>
+{
     /// A raw task pointer.
     pub(crate) raw_task: NonNull<()>,
 
     /// A marker capturing generic types `R` and `T`.
-    pub(crate) _marker: PhantomData<(R, T)>,
+    pub(crate) _marker: PhantomData<(R, T, &'a R)>,
 }
 
-unsafe impl<R: Send, T> Send for JoinHandle<R, T> {}
-unsafe impl<R, T> Sync for JoinHandle<R, T> {}
+unsafe impl<'a, R: Send, T> Send for JoinHandle<'a, R, T> {}
+unsafe impl<'a, R, T> Sync for JoinHandle<'a, R, T> {}
 
-impl<R, T> Unpin for JoinHandle<R, T> {}
+impl<'a, R, T> Unpin for JoinHandle<'a, R, T> {}
 
-impl<R, T> JoinHandle<R, T> {
+impl<'a, R, T> JoinHandle<'a, R, T> {
     /// Cancels the task.
     ///
     /// If the task has already completed, calling this method will have no effect.
@@ -104,7 +105,7 @@ impl<R, T> JoinHandle<R, T> {
     }
 }
 
-impl<R, T> Drop for JoinHandle<R, T> {
+impl<'a, R, T> Drop for JoinHandle<'a, R, T> {
     fn drop(&mut self) {
         let ptr = self.raw_task.as_ptr();
         let header = ptr as *const Header;
@@ -185,7 +186,7 @@ impl<R, T> Drop for JoinHandle<R, T> {
     }
 }
 
-impl<R, T> Future for JoinHandle<R, T> {
+impl<'a, R, T> Future for JoinHandle<'a, R, T> {
     type Output = Option<R>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -266,7 +267,7 @@ impl<R, T> Future for JoinHandle<R, T> {
     }
 }
 
-impl<R, T> fmt::Debug for JoinHandle<R, T> {
+impl<'a, R, T> fmt::Debug for JoinHandle<'a, R, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let ptr = self.raw_task.as_ptr();
         let header = ptr as *const Header;

--- a/src/task.rs
+++ b/src/task.rs
@@ -47,12 +47,12 @@ use crate::JoinHandle;
 /// // Create a task with the future and the schedule function.
 /// let (task, handle) = async_task::spawn(future, schedule, ());
 /// ```
-pub fn spawn<F, R, S, T>(future: F, schedule: S, tag: T) -> (Task<T>, JoinHandle<R, T>)
+pub fn spawn<'a, F, R, S, T>(future: F, schedule: S, tag: T) -> (Task<T>, JoinHandle<'a, R, T>)
 where
-    F: Future<Output = R> + Send + 'static,
-    R: Send + 'static,
-    S: Fn(Task<T>) + Send + Sync + 'static,
-    T: Send + Sync + 'static,
+    F: Future<Output = R> + Send + 'a,
+    R: Send + 'a,
+    S: Fn(Task<T>) + Send + Sync + 'a,
+    T: Send + Sync + 'a,
 {
     // Allocate large futures on the heap.
     let raw_task = if mem::size_of::<F>() >= 2048 {
@@ -113,12 +113,12 @@ where
 /// let (task, handle) = async_task::spawn_local(future, schedule, ());
 /// ```
 #[cfg(feature = "std")]
-pub fn spawn_local<F, R, S, T>(future: F, schedule: S, tag: T) -> (Task<T>, JoinHandle<R, T>)
+pub fn spawn_local<'a, F, R, S, T>(future: F, schedule: S, tag: T) -> (Task<T>, JoinHandle<'a, R, T>)
 where
-    F: Future<Output = R> + 'static,
-    R: 'static,
-    S: Fn(Task<T>) + Send + Sync + 'static,
-    T: Send + Sync + 'static,
+    F: Future<Output = R> + 'a,
+    R: 'a,
+    S: Fn(Task<T>) + Send + Sync + 'a,
+    T: Send + Sync + 'a,
 {
     extern crate std;
 


### PR DESCRIPTION
Current spawn API's limit spawned futures to `'static`. I wonder why that is, given that we now have a `JoinHandle` type which could be used to feed through a lifetime.

I did a quick experiment here which seems like the compiler should be able to deal with this. It is completely experimental and not ready for merging. I haven't checked any of the variance issues, nor done any testing.

One major issue I see is that `JoinHandle` detaches on drop. Obviously the lifetime of the future in the executor should be limited to the lifetime of any borrows inside of it. If `JoinHandle` is what let's the compiler verify this, then when it is dropped the task must be dropped instantly I think. That is not included in this PR.

I'm just hoping to get some feedback as to whether this is at all possible, or is there some fundamental problem I'm overlooking? There is a little example included that borrows in a spawned future.

I also didn't do much research into prior work. I just now found https://github.com/rmanoka/async-scoped which seems to do something similar with async-std as a backend. This approach would allow this to work without having to create scope closures however.

Ideally I would like to see this supported by all executors and include it in the `SpawnHandle` and `JoinHandle` types of [async_executors](https://crates.io/crates/async_executors) as well as support it in a [nursery](https://vorpus.org/blog/notes-on-structured-concurrency-or-go-statement-considered-harmful/) I'm working on for rust.

update: `std::mem::forget` is a problem as well. Particularly, we should never poll the future again when the lifetime has expired, but `std::task::Waker` is not bound by a lifetime, so the moment `wake` is called is only known at runtime it seems, which probably means it's impossible for the compiler to check that...